### PR TITLE
FPagination - Correção do calculo de paginas a serem renderizadas #95

### DIFF
--- a/src/components/FPagination/FPagination.vue
+++ b/src/components/FPagination/FPagination.vue
@@ -81,8 +81,10 @@ export default {
     },
 
     show() {
-      const result = Array.from({ length: this.max }, (e, i) =>
-        this.pgFrom + this.max > this.totalPages
+      const length = Math.min(this.totalPages, this.max)
+
+      const result = Array.from({ length }, (e, i) =>
+        this.pgFrom + length > this.totalPages
           ? this.totalPages + 1 - (this.max - i)
           : this.pgFrom <= 0
           ? i + 1


### PR DESCRIPTION
Corrige Issue #95 onde `FPagination` renderizava paginas negativos quando o total de páginas a serem renderizadas é menor que o valor da prop `max`. Closes #95 