### PR TITLE
FPagination - Hotfix de bug de renderização de paginação

### DIFF
--- a/src/components/FPagination/FPagination.vue
+++ b/src/components/FPagination/FPagination.vue
@@ -73,7 +73,9 @@ export default {
     },
 
     pgFrom() {
-      return this.currentPage - Math.ceil(this.max / 2)
+      return this.totalPages > this.max
+        ? this.currentPage - Math.ceil(this.max / 2)
+        : 0
     },
 
     show() {


### PR DESCRIPTION
Corrige bug de renderização do `FPagination` quando total de páginas é menor que valor da prop `max` e a página atual corresponde à `max - 2`

![Screen Shot 2020-03-31 at 10 27 25](https://user-images.githubusercontent.com/3172683/78033683-1625d980-733d-11ea-84a8-74f9c65a8822.png)
Na screenshot acima o total de páginas é `7`, valor da prop `max` é `10` e página atual é `7`