### PR TITLE
fixing input type number issues

### DIFF
--- a/src/components/FField/FInputType.vue
+++ b/src/components/FField/FInputType.vue
@@ -14,13 +14,12 @@
       {{ message }}
     </div>
     <input
+      :type="type"
+      v-model="value"
       :disabled="disabled"
-      :value="value"
       :placeholder="placeHolder"
       class="f-input__input"
       :class="[colorText, inputFontSize, inputFontWeight]"
-      @keydown.up="counterUp($event)"
-      @keydown.down="counterDown($event)"
     />
     <div class="f-input__unity" :class="[unityFontSize, colorText]">
       {{ unity }}


### PR DESCRIPTION
Nesse fix foi corrigido o problema de não ser emitido o valor do input quando o mesmo era alterado manualmente.
As alterações feitas foram:
Remoção dos eventos @keyup e @keydown que deixaram de ser necessários quando a tipo do input é number, pois por padrão, o input já vem com essa ação.
Chamada da prop type que já estava declarada mas não estava sendo usada, prop essa, que, foi responsável pela opção de eliminar os eventos citados acima e dar a característica necessária ao input.
Troca do bind dos dados do value pelo v-model que não era utilizado no input e resolveu a questão de atualizar os valores do input em tempo real além de emitir os valores