### PR TITLE
Fix/multi select icon click

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@doc88/flux-style-guide",
-  "version": "1.4.6-beta.1",
+  "version": "1.4.7-beta.1",
   "license": "MIT",
   "main": "src/index.esm.js",
   "scripts": {

--- a/src/components/FMultiSelect/FMultiSelect.vue
+++ b/src/components/FMultiSelect/FMultiSelect.vue
@@ -152,7 +152,8 @@ export default {
     return {
       sortedOptions: [],
       displayOptions: false,
-      searchQuery: ''
+      searchQuery: '',
+      toggling: false
     }
   },
 
@@ -200,7 +201,11 @@ export default {
 
   watch: {
     displayOptions(display) {
+      this.toggling = true
       if (display) this.sortOptions()
+      setTimeout(() => {
+        this.toggling = false
+      }, 100)
     },
     searchQuery: 'debounceInput',
     options: 'setSortedOptions'
@@ -238,7 +243,9 @@ export default {
       this.displayOptions = value || !this.displayOptions
     },
     hideOptions() {
-      this.displayOptions = false
+      if (!this.toggling) {
+        this.displayOptions = false
+      }
     },
     sortOptions() {
       this.setSortedOptions()


### PR DESCRIPTION
Em um componente f-multiple-select, quando a propriedade search está ativa alguns lugares não abrem o menu ao clicar
![image](https://user-images.githubusercontent.com/9284273/108107109-90527000-706d-11eb-9b40-695087ced688.png)
